### PR TITLE
p1: detect gas from /gas endpoint instead of gas_meter_code

### DIFF
--- a/drivers/p1/device.ts
+++ b/drivers/p1/device.ts
@@ -73,40 +73,47 @@ module.exports = class SolarplanP1Device extends Homey.Device {
       this.setValues(meta);
     }
 
-    if (meta.gas_meter_code) {
-      let respGas = await zonneplanApi.getGas(conn);
-      if (respGas !== undefined && respGas.data !== undefined) {
-        this.log(respGas.data.measurement_groups);
+    // Gas detection: don't rely on the contract's `gas_meter_code` (Zonneplan leaves it
+    // null on some p1_installation contracts even when gas exists). Instead ask the
+    // connection's /gas endpoint directly and treat a valid measurement_groups payload
+    // as "this connection has gas". All-electric connections return an empty body.
+    let respGas: any = undefined;
+    try {
+      if (conn) respGas = await zonneplanApi.getGas(conn);
+    } catch (gasError: any) {
+      this.log('Error while fetching gas: ' + (gasError && gasError.message));
+    }
+    if (respGas !== undefined && respGas.data !== undefined && Array.isArray(respGas.data.measurement_groups)) {
+      this.log(respGas.data.measurement_groups);
 
-        if (!this.hasCapability('meter_gas.daily')) await this.addCapability('meter_gas.daily');
-        var gasDaily = respGas.data.measurement_groups[0].total / 1000;
-        this.setCapabilityValue('meter_gas.daily', gasDaily);
+      if (!this.hasCapability('meter_gas.daily')) await this.addCapability('meter_gas.daily');
+      var gasDaily = respGas.data.measurement_groups[0].total / 1000;
+      this.setCapabilityValue('meter_gas.daily', gasDaily);
 
-        if (!this.hasCapability('meter_gas.daily_price')) await this.addCapability('meter_gas.daily_price');
-        var priceDaily = respGas.data.measurement_groups[0].meta.delivery_costs_incl_tax / 10000000;
-        this.setCapabilityValue('meter_gas.daily_price', priceDaily);
+      if (!this.hasCapability('meter_gas.daily_price')) await this.addCapability('meter_gas.daily_price');
+      var priceDaily = respGas.data.measurement_groups[0].meta.delivery_costs_incl_tax / 10000000;
+      this.setCapabilityValue('meter_gas.daily_price', priceDaily);
 
-        if (!this.hasCapability('meter_gas.monthly')) await this.addCapability('meter_gas.monthly');
-        var gasMonthly = respGas.data.measurement_groups[1].total / 1000;
-        this.setCapabilityValue('meter_gas.monthly', gasMonthly);
+      if (!this.hasCapability('meter_gas.monthly')) await this.addCapability('meter_gas.monthly');
+      var gasMonthly = respGas.data.measurement_groups[1].total / 1000;
+      this.setCapabilityValue('meter_gas.monthly', gasMonthly);
 
-        if (!this.hasCapability('meter_gas.monthly_price')) await this.addCapability('meter_gas.monthly_price');
-        var priceMonthly = respGas.data.measurement_groups[1].meta.delivery_costs_incl_tax / 10000000;
-        this.setCapabilityValue('meter_gas.monthly_price', priceMonthly);
+      if (!this.hasCapability('meter_gas.monthly_price')) await this.addCapability('meter_gas.monthly_price');
+      var priceMonthly = respGas.data.measurement_groups[1].meta.delivery_costs_incl_tax / 10000000;
+      this.setCapabilityValue('meter_gas.monthly_price', priceMonthly);
 
-        if (this.validResult(respGas.data.measurement_groups[2].total)) {
-          if (!this.hasCapability('meter_gas.yearly')) await this.addCapability('meter_gas.yearly');
-          if (!this.hasCapability('meter_gas')) await this.addCapability('meter_gas');
-          var gas = respGas.data.measurement_groups[2].total / 1000;
-          this.setCapabilityValue('meter_gas.yearly', gas);
-          this.setCapabilityValue('meter_gas', gas);
-        }
+      if (this.validResult(respGas.data.measurement_groups[2].total)) {
+        if (!this.hasCapability('meter_gas.yearly')) await this.addCapability('meter_gas.yearly');
+        if (!this.hasCapability('meter_gas')) await this.addCapability('meter_gas');
+        var gas = respGas.data.measurement_groups[2].total / 1000;
+        this.setCapabilityValue('meter_gas.yearly', gas);
+        this.setCapabilityValue('meter_gas', gas);
+      }
 
-        if (this.validResult(respGas.data.measurement_groups[2].meta.delivery_costs_incl_tax)) {
-          if (!this.hasCapability('meter_gas.yearly_price')) await this.addCapability('meter_gas.yearly_price');
-          var price = respGas.data.measurement_groups[2].meta.delivery_costs_incl_tax / 10000000;
-          this.setCapabilityValue('meter_gas.yearly_price', price);
-        }
+      if (this.validResult(respGas.data.measurement_groups[2].meta.delivery_costs_incl_tax)) {
+        if (!this.hasCapability('meter_gas.yearly_price')) await this.addCapability('meter_gas.yearly_price');
+        var price = respGas.data.measurement_groups[2].meta.delivery_costs_incl_tax / 10000000;
+        this.setCapabilityValue('meter_gas.yearly_price', price);
       }
     } else {
       if (this.hasCapability('meter_gas')) await this.removeCapability('meter_gas');


### PR DESCRIPTION
## Problem

On some Zonneplan accounts the P1 device never exposes gas, even though gas is clearly visible in the Zonneplan app itself and the household has a gas meter.

Root cause: the gas block is gated on `meta.gas_meter_code` of the **p1_installation** contract. On these accounts Zonneplan leaves `gas_meter_code = null` on that contract (gas is modelled as a separate contract), so the gate is false, the `/gas` fetch is skipped entirely, and all `meter_gas*` capabilities get removed — so gas never reaches Homey Energy.

But `GET /connections/{connection_uuid}/gas` for the P1's own connection **does** return valid `measurement_groups` (today / month / year totals + costs). The data is there; only the gate is wrong.

Verified live against such an account: with the `gas_meter_code` gate the device had 0 gas capabilities; after this change it reports `meter_gas` = 464.14 m³ (year), `meter_gas.daily` 0.76 m³, `meter_gas.monthly` 32.9 m³, plus the price sub-capabilities, and gas shows up in the Energy tab.

## Change

- Fetch `/gas` for the connection unconditionally and gate on a valid `measurement_groups` array instead of `gas_meter_code`.
- All-electric connections return an empty body → falls through to the existing capability-removal `else`, so no behaviour change for them.
- Wrap the gas fetch in try/catch so a transient gas error no longer aborts `syncDevice` before the electricity update runs (this fetch now happens for every user each poll).

No changes to parsing/indices or the removal path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)